### PR TITLE
纳入年终奖计算修复三端展示

### DIFF
--- a/platforms/browser-extension/src/popup/popup.js
+++ b/platforms/browser-extension/src/popup/popup.js
@@ -546,7 +546,9 @@ document.addEventListener('DOMContentLoaded', function () {
     }
     
     // 使用 settings 对象中正确的、扁平化的属性结构
-    const monthlyIncome = parseFloat(settings.salary);
+    const baseMonthlyIncome = parseFloat(settings.salary);
+    const annualBonus = settings.bonus ? parseFloat(settings.bonus) : 0;
+    const monthlyIncome = baseMonthlyIncome + (annualBonus / 12);
     const workDays = settings.workDays || [1, 2, 3, 4, 5];
     const workStart = settings.workStart || '09:00';
     const workEnd = settings.workEnd || '18:00';


### PR DESCRIPTION
## Summary
- 浏览器插件按月折算年终奖，确保日收入与进度使用包含年终奖的月均收入
- iOS 客户端增加年终奖输入并折算到时薪，实时同步至计薪与 Live Activity 显示

## Testing
- npm run build --workspace @happy-work/browser-extension

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925129abcd4832288ad66f9867e8e1b)