### PR TITLE
修复实时收入与今日到手展示逻辑

### DIFF
--- a/platforms/browser-extension/src/popup/popup.js
+++ b/platforms/browser-extension/src/popup/popup.js
@@ -604,6 +604,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // 更新UI - 实时收入
+    displayIncome = currentBaseIncome;
     const previousDisplayIncome = parseFloat(incomeValue.textContent.replace('¥', '')) || displayIncome;
     animateValue(incomeValue, previousDisplayIncome, displayIncome, 500);
     
@@ -612,14 +613,11 @@ document.addEventListener('DOMContentLoaded', function () {
     incomePercent.textContent = `${Math.min(100, progressPercent).toFixed(0)}%`;
     
     // 更新UI - 今日收入
-    let todayDisplayIncome;
-    let todayIncomeLabel = '今日到手';
-    if (progressPercent >= 100 || !isCurrentlyWorkingCheck) {
-      todayDisplayIncome = currentBaseIncome;
-      todayIncomeLabel = '今日实收';
-    } else {
-      todayDisplayIncome = dailyIncome * todayWorkInfo.multiplier;
-    }
+    const targetDailyIncome = dailyIncome * todayWorkInfo.multiplier;
+    const hasCompletedWork = progressPercent >= 100;
+
+    const todayIncomeLabel = hasCompletedWork ? '今日实收' : '今日到手';
+    const todayDisplayIncome = hasCompletedWork ? currentBaseIncome : targetDailyIncome;
     document.querySelector('.today-label').textContent = todayIncomeLabel;
     todayValue.textContent = `¥${Math.round(todayDisplayIncome)}`;
 


### PR DESCRIPTION
## Summary
- 修正实时收入显示以使用最新的收入计算结果，避免出现不随时间更新的问题
- 调整今日到手/今日实收的切换逻辑，在午休或尚未上班时保持展示目标金额，完成工作后再展示实收

## Testing
- npm run build --workspace @happy-work/browser-extension

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694100a71dc08322ae2aa3900f3d3c3c)